### PR TITLE
Use custom dimension config as fallback

### DIFF
--- a/Archiver.php
+++ b/Archiver.php
@@ -22,17 +22,12 @@ class Archiver extends \Piwik\Plugin\Archiver
     const LABEL_CUSTOM_VALUE_NOT_DEFINED = "Value not defined";
     const CUSTOM_VARIABLE_RECORD_NAME = 'CustomVariables_valueByName';
 
-    // Ecommerce reports use custom variables.
-    // We specifically set the limits high to get accurate Ecommerce reports
-    const MAX_ROWS_WHEN_ECOMMERCE = 50000;
-
     /**
      * @var DataArray
      */
     protected $dataArray;
     protected $maximumRowsInDataTableLevelZero;
     protected $maximumRowsInSubDataTable;
-    protected $newEmptyRow;
 
     private $metadata = array();
     private $metadataFlat = array();
@@ -41,13 +36,8 @@ class Archiver extends \Piwik\Plugin\Archiver
     {
         parent::__construct($processor);
 
-        if ($processor->getParams()->getSite()->isEcommerceEnabled()) {
-            $this->maximumRowsInDataTableLevelZero = self::MAX_ROWS_WHEN_ECOMMERCE;
-            $this->maximumRowsInSubDataTable = self::MAX_ROWS_WHEN_ECOMMERCE;
-        } else {
-            $this->maximumRowsInDataTableLevelZero = Config::getInstance()->General['datatable_archiving_maximum_rows_custom_variables'];
-            $this->maximumRowsInSubDataTable = Config::getInstance()->General['datatable_archiving_maximum_rows_subtable_custom_variables'];
-        }
+        $this->maximumRowsInDataTableLevelZero = Config::getInstance()->General['datatable_archiving_maximum_rows_custom_variables'] ?? Config::getInstance()->General['datatable_archiving_maximum_rows_custom_dimensions'];
+        $this->maximumRowsInSubDataTable = Config::getInstance()->General['datatable_archiving_maximum_rows_subtable_custom_variables'] ?? Config::getInstance()->General['datatable_archiving_maximum_rows_subtable_custom_dimensions'];
     }
 
     public function aggregateMultipleReports()


### PR DESCRIPTION
The ecommerce config override is no longer needed, as the ecommerce stuff isn't stored in custom variables anymore.

refs https://github.com/matomo-org/matomo/pull/16229