### PR TITLE
Ensure console commands return integers

### DIFF
--- a/Commands/Info.php
+++ b/Commands/Info.php
@@ -34,7 +34,7 @@ class Info extends ConsoleCommand
             $this->writeSuccessMessage($output, array(
                 'Your Piwik is configured for ' . $maxVars . ' custom variables.'
             ));
-            return;
+            return 0;
         }
 
         $output->writeln('<error>There is a problem with your custom variables configuration:</error>');
@@ -46,6 +46,8 @@ class Info extends ConsoleCommand
         foreach (Model::getScopes() as $scope) {
             $output->writeln(Common::prefixTable($scope));
         }
+
+        return 0;
     }
 
     private function hasEverywhereSameAmountOfVariables()

--- a/Commands/SetNumberOfCustomVariables.php
+++ b/Commands/SetNumberOfCustomVariables.php
@@ -45,7 +45,7 @@ class SetNumberOfCustomVariables extends ConsoleCommand
             $this->writeSuccessMessage($output, array(
                 'Your Piwik is already configured for ' . $numVarsToSet . ' custom variables.'
             ));
-            return;
+            return 0;
         }
 
         $output->writeln('');
@@ -56,7 +56,7 @@ class SetNumberOfCustomVariables extends ConsoleCommand
         }
 
         if ($input->isInteractive() && !$this->confirmChange($output)) {
-            return;
+            return 0;
         }
 
         $output->writeln('');
@@ -75,6 +75,8 @@ class SetNumberOfCustomVariables extends ConsoleCommand
         $this->writeSuccessMessage($output, array(
             'Your Piwik is now configured for ' . $numVarsToSet . ' custom variables.'
         ));
+
+        return 0;
     }
 
     private function initProgress($numChangesToPerform, OutputInterface $output)


### PR DESCRIPTION
### Description:

Newer versions of symfony console will throw an error when a console command does not return an integer.

[ignore_release]

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
