### PR TITLE
Replace substr() with mb_substr() to correctly cut utf8 values

### DIFF
--- a/Tracker/CustomVariablesRequestProcessor.php
+++ b/Tracker/CustomVariablesRequestProcessor.php
@@ -135,6 +135,6 @@ class CustomVariablesRequestProcessor extends RequestProcessor
 
     public static function truncateCustomVariable($input)
     {
-        return substr(trim($input), 0, CustomVariables::getMaxLengthCustomVariables());
+        return mb_substr(trim($input), 0, CustomVariables::getMaxLengthCustomVariables());
     }
 }


### PR DESCRIPTION
see https://github.com/matomo-org/plugin-CustomVariables/issues/40