### PR TITLE
Fix uncaught exception in getCustomVariables()

### DIFF
--- a/Tracker/CustomVariablesRequestProcessor.php
+++ b/Tracker/CustomVariablesRequestProcessor.php
@@ -110,6 +110,10 @@ class CustomVariablesRequestProcessor extends RequestProcessor
         foreach ($customVar as $id => $keyValue) {
             $id = (int)$id;
 
+            if (!is_array($keyValue)) {
+                continue;
+            }
+            
             if ($id < 1
                 || $id > $maxCustomVars
                 || count($keyValue) != 2


### PR DESCRIPTION
This fixes
> Uncaught exception in plugins/CustomVariables/Tracker/CustomVariablesRequestProcessor.php line 116:
> count(): Argument 1 ($value) must be of type Countable|array, string given

Happens because "_cvar" is sometimes passed like this:
```
  ["_cvar"]=>
  string(71) "[null,null,null,null,["wp","ch24_v_go_104"],["device_output","mobile"]]"
```
In this case "$customVar" will have the value:
```
  array(6) {
  [0]=>
  string(0) ""
  [1]=>
  string(0) ""
  [2]=>
  string(0) ""
  [3]=>
  string(0) ""
  [4]=>
  array(2) {
    [0]=>
    string(2) "wp"
    [1]=>
    string(10) "ch24_v_gob"
  }
  [5]=>
  array(2) {
    [0]=>
    string(13) "device_output"
    [1]=>
    string(7) "desktop"
  }
}
```