### PR TITLE
Fix a "passing null  to parameter" warning

### DIFF
--- a/Archiver.php
+++ b/Archiver.php
@@ -129,7 +129,7 @@ class Archiver extends \Piwik\Plugin\Archiver
 
     protected function cleanCustomVarValue($value)
     {
-        if (strlen($value)) {
+        if ($value !== null && strlen($value)) {
             return $value;
         }
         return self::LABEL_CUSTOM_VALUE_NOT_DEFINED;


### PR DESCRIPTION
This fixes:
```
WARNING CustomVariables
plugins/CustomVariables/Archiver.php(134):
Deprecated - strlen(): Passing null to parameter #1 ($string) of type string is deprecated
```