### PR TITLE
update getPageUrls expected fixtures for subtable conversion rate fix

### DIFF
--- a/tests/System/expected/test_twoVisitsWithCustomVariables_SegmentPageTitleContains__Actions.getPageUrls_day.xml
+++ b/tests/System/expected/test_twoVisitsWithCustomVariables_SegmentPageTitleContains__Actions.getPageUrls_day.xml
@@ -97,7 +97,7 @@
 						<revenue>0</revenue>
 						<nb_conv_pages_before>3</nb_conv_pages_before>
 						<nb_conversions_attrib>0.6666</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>1</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>0</revenue_attrib>
 					</row>

--- a/tests/System/expected/test_twoVisitsWithCustomVariables_SegmentPageUrlContains__Actions.getPageUrls_day.xml
+++ b/tests/System/expected/test_twoVisitsWithCustomVariables_SegmentPageUrlContains__Actions.getPageUrls_day.xml
@@ -97,7 +97,7 @@
 						<revenue>0</revenue>
 						<nb_conv_pages_before>3</nb_conv_pages_before>
 						<nb_conversions_attrib>0.6666</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>1</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>0</revenue_attrib>
 					</row>

--- a/tests/System/expected/test_twoVisitsWithCustomVariables_SegmentPageUrlEndsWith__Actions.getPageUrls_day.xml
+++ b/tests/System/expected/test_twoVisitsWithCustomVariables_SegmentPageUrlEndsWith__Actions.getPageUrls_day.xml
@@ -97,7 +97,7 @@
 						<revenue>0</revenue>
 						<nb_conv_pages_before>3</nb_conv_pages_before>
 						<nb_conversions_attrib>0.6666</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>1</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>0</revenue_attrib>
 					</row>

--- a/tests/System/expected/test_twoVisitsWithCustomVariables_SegmentPageUrlStartsWith__Actions.getPageUrls_day.xml
+++ b/tests/System/expected/test_twoVisitsWithCustomVariables_SegmentPageUrlStartsWith__Actions.getPageUrls_day.xml
@@ -99,7 +99,7 @@
 						<revenue>0</revenue>
 						<nb_conv_pages_before>3</nb_conv_pages_before>
 						<nb_conversions_attrib>0.6666</nb_conversions_attrib>
-						<nb_conversions_page_rate>0</nb_conversions_page_rate>
+						<nb_conversions_page_rate>1</nb_conversions_page_rate>
 						<nb_conversions_page_uniq>2</nb_conversions_page_uniq>
 						<revenue_attrib>0</revenue_attrib>
 					</row>


### PR DESCRIPTION

## Description
Companion to matomo-org/matomo DEV-13925, which fixes CalculateConversionPageRate to recurse into subtables. Previously the subtable rows had nb_conversions_page_rate frozen at 0; with the core fix they now report the correct ratio.

## Issue No
https://innocraft.atlassian.net/browse/DEV-13925

## Steps to Replicate the Issue



## Checklist
- [✔] Tested locally or on demo2/demo3?
- [✔] New test case added/updated?
- [NA] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [NA] Version bumped? - Not sure on this one
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
- [NA] Documentation updated?
